### PR TITLE
[0.1.0] Add tag as an optional argument, by default set to `latest`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,4 @@ export PORTER_TOKEN=${INPUT_TOKEN:?input \"token\" not set or empty}
 
 : "${INPUT_APP:?input \"app\" not set or empty}"
 
-porter update --app "$INPUT_APP"
+porter update --app "$INPUT_APP" --tag $(git rev-parse --short HEAD)


### PR DESCRIPTION
Need to add the tag as an argument so we can set it to the git short SHA ref. Will be set as `latest` by default for users not writing the file through Porter. 