### PR TITLE
[0.1.0] Add `namespace` as option to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: tag for the created image
     required: false
     default: latest
+  namespace:
+    description: namespace for the application
+    required: false
+    default: default
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,6 @@ export PORTER_TOKEN=${INPUT_TOKEN:?input \"token\" not set or empty}
 
 : "${INPUT_APP:?input \"app\" not set or empty}"
 : "${INPUT_TAG:?input \"tag\" not set or empty}"
+: "${INPUT_NAMESPACE:?input \"namespace\" not set or empty}"
 
-porter update --app "$INPUT_APP" --tag "$INPUT_TAG"
+porter update --app "$INPUT_APP" --tag "$INPUT_TAG" --namespace "$INPUT_NAMESPACE"


### PR DESCRIPTION
Users need to be able to deploy in a different namespace than `default`. Added as an optional argument, by default set to `default`. 