### PR TITLE
Add `namespace`, `tag` inputs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Configuration Options
 
 The possible inputs are:
 
-- `app`: (string, required) Name of application.
+- `app`: (string, required): Name of application.
 - `cluster`: (number, required): Cluster ID of Porter cluster.
 - `host`: (string, optional): Host URL of Porter instance. Set this if you use a self-hosted Porter instance.
+- `namespace`: (string, optional): Namespace of the application (default "default")
 - `project`: (number, required): Project ID of Porter project.
+- `tag` (string, optional): The specified tag to use (default "latest")
 - `token`: (string, required): Token for Porter authentication.


### PR DESCRIPTION
With this PR, the `README` should now list all inputs